### PR TITLE
Add alt text to key interface images

### DIFF
--- a/src/components/icon-button.tsx
+++ b/src/components/icon-button.tsx
@@ -4,12 +4,14 @@ import './icon-button.scss';
 type Props = {
     className?: string,
     icon: string,
+    alt?: string,
     onClick: () => void
 }
 
-export const IconButton = ({ className, icon, onClick }: Props) => (
+export const IconButton = ({ className, icon, alt = '', onClick }: Props) => (
     <img
         className={combineClassNames('icon-button', className)}
         src={icon}
+        alt={alt}
         onClick={onClick} />
 )

--- a/src/home/home.tsx
+++ b/src/home/home.tsx
@@ -52,10 +52,10 @@ export const Home = () => {
             </p>
             <div className='projects'>
                 <a href='https://join.slack.com/t/quraniccorpus/shared_invite/zt-1zp5zdz5w-b7hbwYPlZABDMm19ZeKWdA'>
-                    <img src={slack} />
+                    <img src={slack} alt='Join the Quranic Arabic Corpus Slack workspace' />
                 </a>
                 <a href='https://github.com/kaisdukes/quranic-corpus'>
-                    <img src={github} />
+                    <img src={github} alt='View the Quranic Arabic Corpus GitHub repository' />
                 </a>
             </div>
             <Footer />

--- a/src/navigation/hamburger-menu.tsx
+++ b/src/navigation/hamburger-menu.tsx
@@ -41,7 +41,7 @@ export const HamburgerMenu = ({ onClose }: Props) => {
         <div className='hamburger-menu'>
             <a href='#' onClick={toggleReaderMode}>
                 <div className='icon-container'>
-                    <img src={read} />
+                    <img src={read} alt='' />
                 </div>
                 {readerMode ? 'Detail mode' : 'Reader mode'}
             </a>
@@ -54,7 +54,7 @@ export const HamburgerMenu = ({ onClose }: Props) => {
                             <div className='icon-container'>
                                 {
                                     settingsService.hasTranslation(key) &&
-                                    <img src={tick} />
+                                    <img src={tick} alt='' />
                                 }
                             </div>
                             {name}

--- a/src/navigation/navigation-bar.tsx
+++ b/src/navigation/navigation-bar.tsx
@@ -43,7 +43,7 @@ export const NavigationBar = ({ chapterNumber }: NavigationProps) => {
                     popupRef={hamburgerPopupRef}
                     showPopup={showHamburgerPopup}
                     onShowPopup={setShowHamburgerPopup}>
-                    <img src={hamburger} />
+                    <img src={hamburger} alt='Open menu' />
                 </PopupLink>
             </header>
             {progress && <IndeterminateProgressBar />}

--- a/src/navigation/qaf.tsx
+++ b/src/navigation/qaf.tsx
@@ -4,7 +4,7 @@ import qaf from '../images/qaf-white.svg';
 export const Qaf = () => {
     return (
         <div className='qaf'>
-            <img src={qaf} />
+            <img src={qaf} alt='' />
         </div>
     )
 }

--- a/src/treebank/treebank.tsx
+++ b/src/treebank/treebank.tsx
@@ -99,7 +99,10 @@ export const Treebank = () => {
                     <SyntaxGraphView syntaxGraph={syntaxGraph} />
                     {
                         syntaxGraph.legacyCorpusGraphNumber > 0 &&
-                        <img className='legacy-graph' src={`https://corpus.quran.com/graphimage?id=${syntaxGraph.legacyCorpusGraphNumber}`} />
+                        <img
+                            className='legacy-graph'
+                            src={`https://corpus.quran.com/graphimage?id=${syntaxGraph.legacyCorpusGraphNumber}`}
+                            alt={`Legacy syntax graph ${syntaxGraph.legacyCorpusGraphNumber}`} />
                     }
                 </>
             }

--- a/src/word-by-word/chapter-header.tsx
+++ b/src/word-by-word/chapter-header.tsx
@@ -14,7 +14,9 @@ export const ChapterHeader = ({ chapter }: Props) => {
         <header className='chapter-header'>
             <div className='grid'>
                 <div className='city'>
-                    <img src={chapter.city === 'Makkah' ? makkah : madinah} />
+                    <img
+                        src={chapter.city === 'Makkah' ? makkah : madinah}
+                        alt={chapter.city === 'Makkah' ? 'Revealed in Makkah' : 'Revealed in Madinah'} />
                 </div>
                 <div className='title'>
                     Sūrat {phonetic}

--- a/src/word-by-word/verse-element.tsx
+++ b/src/word-by-word/verse-element.tsx
@@ -26,7 +26,11 @@ export const VerseElement = ({ verse }: Props) => {
         <div id={getVerseId(location)} className='verse-element'>
             <div className='verse-header'>
                 <span className='verse-number'>{location[1]}</span>
-                <IconButton className='copy-button' icon={copy} onClick={handleCopy} />
+                <IconButton
+                    className='copy-button'
+                    icon={copy}
+                    alt='Copy verse'
+                    onClick={handleCopy} />
             </div>
             <div className='verse-tokens'>
                 {verseMark === 'section' && <SectionMark />}


### PR DESCRIPTION
## Summary
- add alt text for meaningful interface images used on the home page, treebank view, navigation menu, and word-by-word reader
- mark decorative icons with empty alt text so screen readers skip them
- allow the IconButton component to accept an optional alt label so clickable icons expose accessible names

## Verification
- npm run build

This branch is based on upstream main to keep the PR limited to a single accessibility fix.